### PR TITLE
Fix typo in manifest url (double /)

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -7,7 +7,7 @@
 	"esmodules": ["about-face.js"],
 	"compatibleCoreVersion": "0.7.8",
 	"minimumCoreVersion": "0.6.0",
-	"manifest": "https://raw.githubusercontent.com/League-of-Foundry-Developers/about-face//master/src/module.json",
+	"manifest": "https://raw.githubusercontent.com/League-of-Foundry-Developers/about-face/master/src/module.json",
 	"download": "https://github.com/League-of-Foundry-Developers/about-face/releases/download/v2.0.3/about-face-v2.0.3.zip",
 	"url": "https://github.com/League-of-Foundry-Developers/about-face",
 	"changelog": "https://github.com/League-of-Foundry-Developers/about-face/blob/v2.0.3/changelog.md",


### PR DESCRIPTION
No consequence since github redirects, but it's nicer without having a redirect or a double `/` in the url