### PR TITLE
Added config option to disable automatic rotation on move

### DIFF
--- a/src/about-face.js
+++ b/src/about-face.js
@@ -81,13 +81,26 @@ Hooks.once("init", () => {
             // we need to update the existing tokenIndicators with the new sprite type.            
             for (const [key, indicator] of Object.entries(AboutFace.tokenIndicators)) {
                 let token = canvas.tokens.get(key);
+                if (token === undefined) continue;
                 log(LogLevel.INFO, 'game.settings onChange, updating TokenIndicator for:', token.name); 
                 indicator.wipe();       
                 await AboutFace.deleteTokenHandler(canvas.scene, token);
                 await AboutFace.createTokenHandler(canvas.scene, token);                            
             }            
         }
-      });
+      })
+
+    game.settings.register(MODULE_ID, 'move-autorotation', {
+        name: "about-face.options.move-autorotation.name",
+        hint: "about-face.options.move-autorotation.hint",
+        scope: "world",
+        config: true,
+        default: true,
+        type: Boolean,
+        onChange: (value) => {
+            AboutFace.moveAutorotation = value;
+        }
+    });
 });
 
 
@@ -99,6 +112,7 @@ export class AboutFace {
         AboutFace.sceneEnabled = true;
         AboutFace.tokenIndicators = {};
         AboutFace.indicatorState;
+        AboutFace.moveAutorotation = true;
     }
     
     static async canvasReadyHandler() {
@@ -148,7 +162,7 @@ export class AboutFace {
         }
 
         // the GM will observe all movement of tokens and set appropriate flags
-        if (game.user.isGM && (updateData.x != null || updateData.y != null || updateData.rotation != null)) {
+        if (game.user.isGM && (AboutFace.moveAutorotation && (updateData.x != null || updateData.y != null) || updateData.rotation != null)) {
             
             if (updateData.rotation != null) return await AboutFace.setTokenFlag(token, 'direction', updateData.rotation);            
             

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -17,5 +17,8 @@
     "about-face.options.indicator-sprite.hint" : "Change the indicator icon (requires reload)",
     "about-face.options.indicator-sprite.choices.normal" : "Normal Indicator",
     "about-face.options.indicator-sprite.choices.large" : "Large Indicator",
-    "about-face.options.indicator-sprite.choices.hex" : "Hex Indicator (Only works on Hex Columns)"
+    "about-face.options.indicator-sprite.choices.hex" : "Hex Indicator (Only works on Hex Columns)",
+
+    "about-face.options.move-autorotation.name": "Automatic rotation on move",
+    "about-face.options.move-autorotation.hint": "If enabled, tokens and their directional indicators will automatically rotate in the direction of movement. If disabled, only manual rotation is possible."
 }

--- a/src/lang/es-ES.json
+++ b/src/lang/es-ES.json
@@ -17,5 +17,8 @@
     "about-face.options.indicator-sprite.hint": "Cambiar el tamaño del indicador (requiere recargar)",
     "about-face.options.indicator-sprite.choices.normal": "Normal",
     "about-face.options.indicator-sprite.choices.large": "Grande",
-    "about-face.options.indicator-sprite.choices.hex" : "Hex Indicator (Only works on Hex Columns)"
+    "about-face.options.indicator-sprite.choices.hex" : "Hex Indicator (Only works on Hex Columns)",
+
+    "about-face.options.move-autorotation.name": "Rotate tokens when moving them",
+    "about-face.options.move-autorotation.hint": "If enabled, tokens and their directional indicators will automatically rotate in the direction fo movement. If disabled, only manual rotation is possible."
 }

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -20,5 +20,8 @@
     "about-face.options.indicator-sprite.hint": "Cambia el tamaño del indicador (requiere recargar el programa)",
     "about-face.options.indicator-sprite.choices.normal": "Normal",
     "about-face.options.indicator-sprite.choices.large": "Grande",
-    "about-face.options.indicator-sprite.choices.hex" : "Hex Indicator (Only works on Hex Columns)"
+    "about-face.options.indicator-sprite.choices.hex" : "Hex Indicator (Only works on Hex Columns)",
+
+    "about-face.options.move-autorotation.name": "Rotate tokens when moving them",
+    "about-face.options.move-autorotation.hint": "If enabled, tokens and their directional indicators will automatically rotate in the direction fo movement. If disabled, only manual rotation is possible."
 }

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -17,5 +17,8 @@
     "about-face.options.indicator-sprite.hint" : "Mudar o icone indicador (requer reinicialização)",
     "about-face.options.indicator-sprite.choices.normal" : "Indicador Normal",
     "about-face.options.indicator-sprite.choices.large" : "Indicador Grande",
-    "about-face.options.indicator-sprite.choices.hex" : "Hex Indicator (Only works on Hex Columns)"
+    "about-face.options.indicator-sprite.choices.hex" : "Hex Indicator (Only works on Hex Columns)",
+
+    "about-face.options.move-autorotation.name": "Rotate tokens when moving them",
+    "about-face.options.move-autorotation.hint": "If enabled, tokens and their directional indicators will automatically rotate in the direction fo movement. If disabled, only manual rotation is possible."
 }

--- a/src/lang/pt_br.json
+++ b/src/lang/pt_br.json
@@ -17,5 +17,8 @@
     "about-face.options.indicator-sprite.hint" : "Mudar o icone indicador (requer reinicialização)",
     "about-face.options.indicator-sprite.choices.normal" : "Indicador Normal",
     "about-face.options.indicator-sprite.choices.large" : "Indicador Grande",
-    "about-face.options.indicator-sprite.choices.hex" : "Hex Indicator (Only works on Hex Columns)"
+    "about-face.options.indicator-sprite.choices.hex" : "Hex Indicator (Only works on Hex Columns)",
+
+    "about-face.options.move-autorotation.name": "Rotate tokens when moving them",
+    "about-face.options.move-autorotation.hint": "If enabled, tokens and their directional indicators will automatically rotate in the direction fo movement. If disabled, only manual rotation is possible."
 }


### PR DESCRIPTION
I'm using the GURPS system for Foundry by @crnormand who previously implemented support for hex indicators here. What I've noticed is that About Face automatically rotates tokens in the direction of movement when tokens are moved. In GURPS, there can be a lot of backpedaling and sidestepping where you move without changing facing, so this behavior can be undesirable.

I've implemented a configuration option which can toggle between this default behavior, and disabling automatic rotation when moving tokens. In this second mode, the tokens can still be rotated manually.

I've also noticed a bug where updating settings would cause updating of sprite types to break in worlds with tokens on multiple scenes. As far as I an see About Face stores the ids of all tokens in a scene into an object (`AboutFace.tokenIndicators`) when the scene is rendered (`canvasReadyHandler`), and these values persist between scene switches so eventually tokens from all scenes end up in this object. During updating of sprite types, all ids from this object are cycled through and each token is loaded from `canvas.tokens` by id, and then its indicator is updated with the new sprite type. So if there were any tokens from other scenes registered in `AboutFace.tokenIndicators`, loading those tokens from `canvas.tokens` returns undefined and updating the indicator throws an exception. I have fixed this so that if `canvas.tokens.get` returns undefined, the loop continues to the next id.