### PR TITLE
Add support for disabling movement-based rotation

### DIFF
--- a/src/about-face.js
+++ b/src/about-face.js
@@ -40,6 +40,19 @@ Hooks.once("init", () => {
         }
       });
     
+    game.settings.register(MODULE_ID, 'disable-move-facing', {
+        name: "about-face.options.disable-move-facing.name",
+        hint: "about-face.options.disable-move-facing.hint",
+        scope: "world",
+        config: true,
+        default: false,
+        type: Boolean,
+        onChange: (value) => {
+            if (!canvas.scene) return;
+            if (isFirstActiveGM()) canvas.scene.setFlag(MODULE_ID, 'disableMoveFacing', value);
+        }
+    });
+
       game.settings.register(MODULE_ID, 'indicator-state', {
         name: "about-face.options.enable-indicator.name",
         hint: "about-face.options.enable-indicator.hint",
@@ -232,7 +245,7 @@ export class AboutFace {
             let direction;
             // if it's a rotation update then set the flag on the relevant token
             if (updateData.rotation != null) direction = updateData.rotation;
-            else {
+            else if (!disableMoveFacing) {
                 // else check for movement
                 const lastPos = new PIXI.Point(AboutFace.tokenIndicators[token.id].token.x, AboutFace.tokenIndicators[token.id].token.y);
                 // calculate new position data

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -2,6 +2,8 @@
     "about-face.options.individual-token-text": "Show indicator for this token?",
     "about-face.options.scene-enabled.name": "Enable About Face on this scene",
     "about-face.options.scene-enabled.hint": "Rotates tokens when moving them (except when locked). If disabled, can still hold shift to rotate in place",    
+		"about-face.options.disable-move-facing.name": "Disable movement-based facing",
+		"about-face.options.disable-move-facing.hint": "Disable token rotation when moving. Can still manually rotate indicator in place even when locked.",
     "about-face.options.enable-indicator.name": "Enable token indicators",
     "about-face.options.enable-indicator.hint": "Adds an indicator for direction to tokens",
     "about-face.options.indicator.choices.0": "Never Show",


### PR DESCRIPTION
Add an off-by-default option that allows for disabling
movement-basedrotation. This supports vehicle combat rules
where the token facing shouldn't change unless manually
rotated.